### PR TITLE
Abolish "&&" operator to support non-bash-compatible shells.

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -427,7 +427,9 @@ xpns_pre_execution() {
   _args4args=$(xpns_arr2args "${XP_ARGS[@]}")
 
   tmux -S "$XP_SOCKET_PATH" send-keys -t "$XP_SESSION_NAME:$XP_TMP_WIN_NAME" \
-    "$XP_ABS_THIS_FILE_NAME $_opts4args $_args4args && exit" C-m
+    "$XP_ABS_THIS_FILE_NAME $_opts4args $_args4args" C-m
+
+  tmux -S "$XP_SOCKET_PATH" send-keys -t "$XP_SESSION_NAME:$XP_TMP_WIN_NAME" "exit" C-m
 
   # Avoid attaching (for unit testing).
   if [ $XP_OPT_ATTACH -eq 1 ]; then


### PR DESCRIPTION
This is try to fixing #47.

Instead of using "&&" operator which is supported by bash, there are some workarounds.
To close particular pane, use either, instead of using `&& exit`...

1. Use semicolon ` ; ` i.e `; exit`
2. Use `tmux send-keys "exit" C-m`.

Second one seems more compatible within various of shells.