### PR TITLE
Add example of running command via SSH on multiple hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,11 @@ File name format for log file can be specified with `--log-format` option. Pleas
 
 **Attention:** Logging feature does not work properly with specific tmux version. Please refer to [wiki > Known Bugs](https://github.com/greymd/tmux-xpanes/wiki/Known-Bugs) in further details.
 
+#### Execute the same sudo command on multiple hosts via SSH, entering your password once
+
+```
+xpanes -c "ssh -t {} 'sudo some command'" host-{1,2} some-third-host.example.com
+```
 
 #### Execute different commands on the different panes.
 


### PR DESCRIPTION
I had trouble figuring this one out, so perhaps someone else will be find the example helpful as well. 

I kept expecting the solution to involve "--ssh" as well. 

It would be nice if a shorter syntax was supported, like one of the following:

```
# New --ssh-c could run command over ssh
xpanes  --ssh-c "sudo-some command" host-{1,2}

# Combining -c and --ssh could mean to run the command via SSH. 
xpanes -c "sudo some-command" --ssh host-{1,2}
```