### PR TITLE
More portable bash shebang

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Let PATH include 'xpanes' and 'tmux-xpanes'.
 if ! (type xpanes > /dev/null 2>&1 &&

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ue
 
 readonly THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"

--- a/man/create.sh
+++ b/man/create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # In bash,
 # Use md2man (https://github.com/sunaku/md2man) to generate man file like this.

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test cases given by this file is not executed on the CI server.
 # This file is just used for brief behavior checking during the development.

--- a/test/update_yaml.sh
+++ b/test/update_yaml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 readonly THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ue
 
 readonly THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"


### PR DESCRIPTION
On some systems (e.g. nixos, freebsd) `bash` might not always be found in `/bin`.
I've fixed the shebang to work on those systems too.