### PR TITLE
Fix version comparison against tmux dev versions

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -235,7 +235,9 @@ xpns_get_tmux_version() {
     _tmux_version="$( ${TMUX_XPANES_EXEC} -V)"
   fi
   read -r _ _ver <<< "${_tmux_version}"
-  echo "${_ver}"
+  # Strip the leading "next-" part that is present in tmux versions that are
+  # in development. Eg: next-3.3
+  echo "${_ver//next-}"
 }
 
 # Check whether the prefered tmux version is greater than host's tmux version.

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -237,7 +237,7 @@ xpns_get_tmux_version() {
   read -r _ _ver <<< "${_tmux_version}"
   # Strip the leading "next-" part that is present in tmux versions that are
   # in development. Eg: next-3.3
-  echo "${_ver//next-}"
+  echo "${_ver//next-/}"
 }
 
 # Check whether the prefered tmux version is greater than host's tmux version.


### PR DESCRIPTION
I'm currently running tmux from git master.

Unrelased tmux versions return their versions with a `next-` prefix, which leads to the version comparison failing, and xpanes then disables the `-t` flag.

This PR should fix that ;)

```
$ tmux -V
next-3.3
```
