### PR TITLE
Optimize xpns_normalize_directory and xpns_is_valid_directory

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -511,13 +511,13 @@ xpns_log_filenames()  {
 # Return:
 #        Normalized <dirname>
 ## --------------------------------
+
 xpns_normalize_directory() {
   # Remove end of slash '/' for the first arguement
   local _dir="${1%/}"
   # tilde expansion
   printf "%s\\n" "${_dir/#~/$HOME}"
 }
-
 ## --------------------------------
 # Ensure existence of given directory
 # Usage:
@@ -536,11 +536,15 @@ xpns_is_valid_directory() {
     fi
     xpns_msg_info "${_dir} is created."
   fi
-  # Check directory permissions
-  if ! [[ -w "${_dir}" ]]; then
+  # Try to create file.
+  #   Not only checking directory permission,
+  #   but also i-node and other misc situations.
+  if ! touch "${_dir}/${_checkfile}"; then
     xpns_msg_error "${_dir} is not writable."
+    rm -f "${_dir}/${_checkfile}"
     exit ${XP_ELOGWRITE}
   fi
+  rm -f "${_dir}/${_checkfile}"
 }
 
 # Convert array to string which is can be used as command line argument.

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -512,43 +512,35 @@ xpns_log_filenames()  {
 #        Normalized <dirname>
 ## --------------------------------
 xpns_normalize_directory() {
-  local _dir="$1"
-  # Remove end of slash '/'
-  _dir="${_dir%/}"
+  # Remove end of slash '/' for the first arguement
+  local _dir="${1%/}"
   # tilde expansion
-  _dir="${_dir/#~/${HOME}}"
-  printf "%s\\n" "${_dir}"
+  printf "%s\\n" "${_dir/#~/$HOME}"
 }
 
 ## --------------------------------
 # Ensure existence of given directory
 # Usage:
-#        xpns_is_valid_directory <direname>
+#        xpns_is_valid_directory <dirname>
 # Return:
 #        Absolute path of the <dirname>
 ## --------------------------------
 xpns_is_valid_directory() {
   local _dir="$1"
-  local _checkfile="${XP_THIS_FILE_NAME}.$$"
   # Check directory.
-  if [[ ! -d "${_dir}" ]]; then
+  if ! [[ -d "${_dir}" ]]; then
     # Create directory
-    if mkdir "${_dir}"; then
-      xpns_msg_info "${_dir} is created."
-    else
+    if ! mkdir "${_dir}"; then
       xpns_msg_error "Failed to create ${_dir}"
       exit ${XP_ELOGDIR}
     fi
+    xpns_msg_info "${_dir} is created."
   fi
-  # Try to create file.
-  #   Not only checking directory permission,
-  #   but also i-node and other misc situations.
-  if ! touch "${_dir}/${_checkfile}"; then
+  # Check directory permissions
+  if ! [[ -w "${_dir}" ]]; then
     xpns_msg_error "${_dir} is not writable."
-    rm -f "${_dir}/${_checkfile}"
     exit ${XP_ELOGWRITE}
   fi
-  rm -f "${_dir}/${_checkfile}"
 }
 
 # Convert array to string which is can be used as command line argument.

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -527,6 +527,7 @@ xpns_normalize_directory() {
 ## --------------------------------
 xpns_is_valid_directory() {
   local _dir="$1"
+  local _checkfile="${XP_THIS_FILE_NAME}.$$"
   # Check directory.
   if ! [[ -d "${_dir}" ]]; then
     # Create directory


### PR DESCRIPTION
xpns_normalize_directory() - instead of calling $_dir variable and change it three times, we just call it once and print it together with /#~/$HOME

xpns_is_valid_directory() - small clean up to improve readability, removing the else to instead use a NOT operator to check if the directory is there or not.

Fixed typo in one comment.

As before, manual testing and smokescreen testing has been done on the code. 
But please check so I have not made any mistake.

Cheers