### PR TITLE
optimize xpns_organize_panes

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -774,20 +774,19 @@ xpns_organize_panes() {
   local _window_name="$1"
   shift
   local _args_num="$1"
-  ## ----------------
+
   # Default behavior
-  ## ----------------
-  if [[ "${_args_num}" -eq 1 ]]; then
-    ${TMUX_XPANES_EXEC} select-layout -t "${_window_name}" even-horizontal
-  elif [[ "${_args_num}" -gt 1 ]]; then
-    ${TMUX_XPANES_EXEC} select-layout -t "${_window_name}" tiled
+  local layout_command="select-layout -t ${_window_name} even-horizontal"
+  if (( _args_num > 1 )); then
+    layout_command="select-layout -t ${_window_name} tiled"
   fi
-  ## ----------------
+
   # Update layout
-  ## ----------------
   if [[ "${XP_LAYOUT}" != "${XP_DEFAULT_LAYOUT}" ]]; then
-    ${TMUX_XPANES_EXEC} select-layout -t "${_window_name}" "${XP_LAYOUT}"
+    layout_command="select-layout -t ${_window_name} ${XP_LAYOUT}"
   fi
+
+  ${TMUX_XPANES_EXEC} $layout_command
 }
 
 #

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -778,7 +778,7 @@ xpns_organize_panes() {
 
   # Default behavior
   local layout_command=" select-layout -t ${_window_name} even-horizontal"
-  if (( _args_num > 1 ));; then
+  if (( _args_num > 1 )); then
     layout_command=" select-layout -t ${_window_name} tiled"
   fi
   # Update layout

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -786,7 +786,7 @@ xpns_organize_panes() {
     layout_command="select-layout -t ${_window_name} ${XP_LAYOUT}"
   fi
 
-  ${TMUX_XPANES_EXEC} $layout_command
+  ${TMUX_XPANES_EXEC} "$layout_command"
 }
 
 #

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -777,10 +777,10 @@ xpns_organize_panes() {
 
   # Default behavior
   local layout_command="select-layout -t ${_window_name} even-horizontal"
-  if (( _args_num > 1 )); then
+  if [[ "${_args_num}" -gt 1 ]]; then
     layout_command="select-layout -t ${_window_name} tiled"
   fi
-
+s
   # Update layout
   if [[ "${XP_LAYOUT}" != "${XP_DEFAULT_LAYOUT}" ]]; then
     layout_command="select-layout -t ${_window_name} ${XP_LAYOUT}"

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -783,7 +783,7 @@ xpns_organize_panes() {
 s
   # Update layout
   if [[ "${XP_LAYOUT}" != "${XP_DEFAULT_LAYOUT}" ]]; then
-    layout_command="select-layout -t ${_window_name} ${XP_LAYOUT}"
+    layout_command=" select-layout -t ${_window_name} ${XP_LAYOUT}"
   fi
 
   ${TMUX_XPANES_EXEC} "$layout_command"

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -561,7 +561,7 @@ xpns_arr2args() {
   if [[ $# -lt 1 ]]; then
     return 0
   fi
-for _arg in "$@"; do
+  for _arg in "$@"; do
     # Use 'cat <<<"input"' command instead of 'echo',
     # because such the command recognizes option like '-e'.
     cat <<< "${_arg}" |
@@ -780,7 +780,6 @@ xpns_organize_panes() {
   if [[ "${_args_num}" -gt 1 ]]; then
     layout_command="select-layout -t ${_window_name} tiled"
   fi
-s
   # Update layout
   if [[ "${XP_LAYOUT}" != "${XP_DEFAULT_LAYOUT}" ]]; then
     layout_command=" select-layout -t ${_window_name} ${XP_LAYOUT}"

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -778,7 +778,7 @@ xpns_organize_panes() {
 
   # Default behavior
   local layout_command=" select-layout -t ${_window_name} even-horizontal"
-  if (( _args_num > 1 )); then
+  if ((_args_num > 1)); then
     layout_command=" select-layout -t ${_window_name} tiled"
   fi
   # Update layout

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -777,16 +777,16 @@ xpns_organize_panes() {
   local _args_num="$1"
 
   # Default behavior
-  local layout_command="select-layout -t ${_window_name} even-horizontal"
+  local layout_command=" select-layout -t ${_window_name} even-horizontal"
   if [[ "${_args_num}" -gt 1 ]]; then
-    layout_command="select-layout -t ${_window_name} tiled"
+    layout_command=" select-layout -t ${_window_name} tiled"
   fi
   # Update layout
   if [[ "${XP_LAYOUT}" != "${XP_DEFAULT_LAYOUT}" ]]; then
     layout_command=" select-layout -t ${_window_name} ${XP_LAYOUT}"
   fi
 
-  ${TMUX_XPANES_EXEC} "$layout_command"
+  ${TMUX_XPANES_EXEC} $layout_command
 }
 
 #

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -778,7 +778,7 @@ xpns_organize_panes() {
 
   # Default behavior
   local layout_command=" select-layout -t ${_window_name} even-horizontal"
-  if [[ "${_args_num}" -gt 1 ]]; then
+  if (( _args_num > 1 ));; then
     layout_command=" select-layout -t ${_window_name} tiled"
   fi
   # Update layout

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -785,7 +785,7 @@ xpns_organize_panes() {
   if [[ "${XP_LAYOUT}" != "${XP_DEFAULT_LAYOUT}" ]]; then
     layout_command=" select-layout -t ${_window_name} ${XP_LAYOUT}"
   fi
-
+  # shellcheck disable=SC2086
   ${TMUX_XPANES_EXEC} $layout_command
 }
 


### PR DESCRIPTION
Instead of calling global ${TMUX_XPANES_EXEC} multiple times, we combine the layout commands into a single local $layout_command string variable and execute it in a single call to ${TMUX_XPANES_EXEC} at the end of the script.

This can should save some overhead and improve readability.

Since ${_args_num} is an integer, it is more efficient to use arithmetic evaluation with (( )) instead of the [[ ]] test operator. So I have changed it to (( _args_num > 1 )).

Please have a look at the commit and make sure its working as intended.

Cheers