### PR TITLE
Add shunit2 dependency for test readme

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,17 +1,25 @@
 # How to maintain test cases
 
-1. Please make sure that GNU sed and [pict](https://github.com/microsoft/pict) are installed.
+1. to test, please make sure that GNU sed, [pict](https://github.com/microsoft/pict) and [shunit2](https://github.com/kward/shunit2.git) are installed.
 
-Example: 
+Example for pict: 
 ```bash
 $ git clone https://github.com/Microsoft/pict.git
 $ cd pict/
-#### Install Clang and libc++ on Ubuntu if necesarry
+#### Install Clang and libc++ on Ubuntu if necessary
 $ sudo apt-get install clang libc++-dev
 $ make
 $ sudo install -m 0755 pict /usr/local/bin/pict
 ```
 
-2. Edit `config.pict` to add/remove/modify software versions.
+Example for shunit2: 
+```bash
+$ git clone https://github.com/kward/shunit2.git
+$ cd shunit2/
+$ cp * /path_to_xpanes_project/test/shunit2/
+```
 
-3. Run `bash ./update_yaml.sh`
+3. Edit `config.pict` to add/remove/modify software versions.
+
+4. Run `bash ./update_yaml.sh`
+

--- a/test/README.md
+++ b/test/README.md
@@ -14,9 +14,10 @@ $ sudo install -m 0755 pict /usr/local/bin/pict
 
 Example for shunit2: 
 ```bash
-$ git clone https://github.com/kward/shunit2.git
-$ cd shunit2/
-$ cp * /path_to_xpanes_project/test/shunit2/
+$ cd /path_to_xpanes_project/test/
+$ git submodule init
+$ git submodule update
+# => https://github.com/kward/shunit2.git is cloned into /path_to_xpanes_project/test/shunit2 directory
 ```
 
 3. Edit `config.pict` to add/remove/modify software versions.


### PR DESCRIPTION
While we do a remote ref to shunit2, pulling the shunit2 project needs to be done manually for our unit testing to work, this notifies the user that its needed as a dependency in the README. Fixed minor typo aswell.

Cheers