### PR TITLE
optimize send_commands() function

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -747,6 +747,29 @@ xpns_set_titles() {
 }
 
 # Send command to the all the panes in the target window.
+#xpns_send_commands() {
+#  local _window_name="$1"
+#  shift
+#  local _index_offset="$1"
+#  shift
+#  local _interval="$1"
+#  shift
+#  local _repstr="$1"
+#  shift
+#  local _cmd="$1"
+#  shift
+#  local _index=0
+#  local _pane_index=
+#  local _exec_cmd=
+#  for arg in "$@"; do
+#    xpns_interval "${_interval}"
+#    _exec_cmd="${_cmd//${_repstr}/${arg}}"
+#    _pane_index=$((_index + _index_offset))
+#    ${TMUX_XPANES_EXEC} send-keys -t "${_window_name}.${_pane_index}" "${_exec_cmd}" C-m
+#    _index=$((_index + 1  ))
+#  done
+#}
+
 xpns_send_commands() {
   local _window_name="$1"
   shift
@@ -759,16 +782,33 @@ xpns_send_commands() {
   local _cmd="$1"
   shift
   local _index=0
-  local _pane_index=
-  local _exec_cmd=
   for arg in "$@"; do
     xpns_interval "${_interval}"
-    _exec_cmd="${_cmd//${_repstr}/${arg}}"
     _pane_index=$((_index + _index_offset))
-    ${TMUX_XPANES_EXEC} send-keys -t "${_window_name}.${_pane_index}" "${_exec_cmd}" C-m
-    _index=$((_index + 1))
+    ${TMUX_XPANES_EXEC} send-keys -t "${_window_name}.${_pane_index}" "${_cmd//${_repstr}/${arg}}" C-m
+    ((_index++))
   done
 }
+
+#xpns_send_commands() {
+#  local _window_name="$1"
+#  shift
+#  local _index_offset="$1"
+#  shift
+#  local _interval="$1"
+#  shift
+#  local _repstr="$1"
+#  shift
+#  local _cmd="$1"
+#  shift
+#  local _index=0
+#  for arg in "$@"; do
+#    _xpns_interval "${_interval}"
+#    _pane_index=$((_index + _index_offset))
+#    ${TMUX_XPANES_EXEC} send-keys -t "${_window_name}.${_pane_index}" "$(printf "%s" "${_cmd//${_repstr}/${_arg}}" | tr '\n' '\r')" C-m
+#    ((_index++))
+#  done
+#}
 
 # Separate window vertically, when the number of panes is 1 or 2.
 xpns_organize_panes() {

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -747,29 +747,6 @@ xpns_set_titles() {
 }
 
 # Send command to the all the panes in the target window.
-#xpns_send_commands() {
-#  local _window_name="$1"
-#  shift
-#  local _index_offset="$1"
-#  shift
-#  local _interval="$1"
-#  shift
-#  local _repstr="$1"
-#  shift
-#  local _cmd="$1"
-#  shift
-#  local _index=0
-#  local _pane_index=
-#  local _exec_cmd=
-#  for arg in "$@"; do
-#    xpns_interval "${_interval}"
-#    _exec_cmd="${_cmd//${_repstr}/${arg}}"
-#    _pane_index=$((_index + _index_offset))
-#    ${TMUX_XPANES_EXEC} send-keys -t "${_window_name}.${_pane_index}" "${_exec_cmd}" C-m
-#    _index=$((_index + 1  ))
-#  done
-#}
-
 xpns_send_commands() {
   local _window_name="$1"
   shift
@@ -789,26 +766,6 @@ xpns_send_commands() {
     ((_index++))
   done
 }
-
-#xpns_send_commands() {
-#  local _window_name="$1"
-#  shift
-#  local _index_offset="$1"
-#  shift
-#  local _interval="$1"
-#  shift
-#  local _repstr="$1"
-#  shift
-#  local _cmd="$1"
-#  shift
-#  local _index=0
-#  for arg in "$@"; do
-#    _xpns_interval "${_interval}"
-#    _pane_index=$((_index + _index_offset))
-#    ${TMUX_XPANES_EXEC} send-keys -t "${_window_name}.${_pane_index}" "$(printf "%s" "${_cmd//${_repstr}/${_arg}}" | tr '\n' '\r')" C-m
-#    ((_index++))
-#  done
-#}
 
 # Separate window vertically, when the number of panes is 1 or 2.
 xpns_organize_panes() {


### PR DESCRIPTION
Instead of declaring the variables, changing them inside the for loop and using them once.
We streamline it to directly call what is taken as arguments to the function. Instead of redeclaring _index with the new value we directly call _index to be increased by one. Providing us with a small performance increase when running the function.

Cheers