### PR TITLE
Merge all option sanitation functions into xpns_opt_checker()

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -1840,77 +1840,17 @@ xpns_warning_before_extra() {
   fi
 }
 
-#xpns_opt_check_number() {
-#  local _option="$1"
-#  shift
-#  local _arg="$1"
-#  if [[ -n "$_arg" ]] && [[ -z "${_arg//[0-9]/}" ]]; then
-#    return 0
-#  fi
-#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-#  exit ${XP_EINVAL}
-#}
-
-#xpns_opt_check_float() {
-#  local _option="$1"
-#  shift
-#  local _arg="$1"
-#  if [[ -n "$_arg" ]] && [[ -z "${_arg//[0-9.]/}" ]]; then
-#    return 0
-#  fi
-#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-#  exit ${XP_EINVAL}
-#}
-#xpns_opt_check_number() {
-#  local _option="$1"
-#  shift
-#  local _arg="$1"
-#  local _check_float="$2"
-#  local _pattern="[0-9]"
-#  if [[ "$_check_float" == "float_true" ]]; then
-#    _pattern="[0-9.]"
-#  fi
-#  if [[ -n "$_arg" ]] && [[ -z "${_arg//$_pattern/}" ]]; then
-#    return 0
-#  fi
-#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-#  exit ${XP_EINVAL}
-#}
-#
-#xpns_opt_check_str() {
-#  local _option="$1"
-#  shift
-#  local _arg="$1"
-#  if [[ -n "$_arg" ]]; then
-#    return 0
-#  fi
-#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-#  exit ${XP_EINVAL}
-#}
-#
-#xpns_opt_check_num_csv() {
-#  local _option="$1"
-#  shift
-#  local _arg="$1"
-#  if [[ "$1" =~ ^([0-9][0-9]*,?)+$ ]]; then
-#    return 0
-#  fi
-#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-#  exit ${XP_EINVAL}
-#}
-
 xpns_opt_checker() {
   local _option="$1"
-  shift
-  local _arg="$1"
-  local _check_float="${2:-default}"
-  #if we do not define a positional parameter, we expect an integer
+  local _arg="$2"
+  local _check_value="${3:-default}"
+  # if we do not define a positional parameter in options, we expect an integer
   local _pattern="[0-9]"
-  if [[ "$_check_float" == "float" ]]; then
+  if [[ "$_check_value" == "float" ]]; then
     _pattern="[0-9.]"
-  elif [[ "$_check_float" == "csv" ]]; then
+  elif [[ "$_check_value" == "csv" ]]; then
     _pattern="^[0-9]+(,[0-9]+)*$"
-  elif [[ "$_check_float" == "string" ]]; then
+  elif [[ "$_check_value" == "string" ]]; then
     if [[ -n "$_arg" ]]; then
       return 0
     fi

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -1840,44 +1840,82 @@ xpns_warning_before_extra() {
   fi
 }
 
-xpns_opt_check_num() {
-  local _option="$1"
-  shift
-  local _arg="$1"
-  if [[ -n "$_arg" ]] && [[ -z "${_arg//[0-9]/}" ]]; then
-    return 0
-  fi
-  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-  exit ${XP_EINVAL}
-}
+#xpns_opt_check_number() {
+#  local _option="$1"
+#  shift
+#  local _arg="$1"
+#  if [[ -n "$_arg" ]] && [[ -z "${_arg//[0-9]/}" ]]; then
+#    return 0
+#  fi
+#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
+#  exit ${XP_EINVAL}
+#}
 
-xpns_opt_check_float() {
-  local _option="$1"
-  shift
-  local _arg="$1"
-  if [[ -n "$_arg" ]] && [[ -z "${_arg//[0-9.]/}" ]]; then
-    return 0
-  fi
-  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-  exit ${XP_EINVAL}
-}
+#xpns_opt_check_float() {
+#  local _option="$1"
+#  shift
+#  local _arg="$1"
+#  if [[ -n "$_arg" ]] && [[ -z "${_arg//[0-9.]/}" ]]; then
+#    return 0
+#  fi
+#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
+#  exit ${XP_EINVAL}
+#}
+#xpns_opt_check_number() {
+#  local _option="$1"
+#  shift
+#  local _arg="$1"
+#  local _check_float="$2"
+#  local _pattern="[0-9]"
+#  if [[ "$_check_float" == "float_true" ]]; then
+#    _pattern="[0-9.]"
+#  fi
+#  if [[ -n "$_arg" ]] && [[ -z "${_arg//$_pattern/}" ]]; then
+#    return 0
+#  fi
+#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
+#  exit ${XP_EINVAL}
+#}
+#
+#xpns_opt_check_str() {
+#  local _option="$1"
+#  shift
+#  local _arg="$1"
+#  if [[ -n "$_arg" ]]; then
+#    return 0
+#  fi
+#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
+#  exit ${XP_EINVAL}
+#}
+#
+#xpns_opt_check_num_csv() {
+#  local _option="$1"
+#  shift
+#  local _arg="$1"
+#  if [[ "$1" =~ ^([0-9][0-9]*,?)+$ ]]; then
+#    return 0
+#  fi
+#  xpns_msg_error "Invalid argument '$_arg' for $_option option"
+#  exit ${XP_EINVAL}
+#}
 
-xpns_opt_check_str() {
+xpns_opt_checker() {
   local _option="$1"
   shift
   local _arg="$1"
-  if [[ -n "$_arg" ]]; then
-    return 0
+  local _check_float="${2:-default}"
+  #if we do not define a positional parameter, we expect an integer
+  local _pattern="[0-9]"
+  if [[ "$_check_float" == "float" ]]; then
+    _pattern="[0-9.]"
+  elif [[ "$_check_float" == "csv" ]]; then
+    _pattern="^[0-9]+(,[0-9]+)*$"
+  elif [[ "$_check_float" == "string" ]]; then
+    if [[ -n "$_arg" ]]; then
+      return 0
+    fi
   fi
-  xpns_msg_error "Invalid argument '$_arg' for $_option option"
-  exit ${XP_EINVAL}
-}
-
-xpns_opt_check_num_csv() {
-  local _option="$1"
-  shift
-  local _arg="$1"
-  if [[ "$1" =~ ^([0-9][0-9]*,?)+$ ]]; then
+  if [[ -n "$_arg" ]] && [[ "$_arg" =~ $_pattern ]]; then
     return 0
   fi
   xpns_msg_error "Invalid argument '$_arg' for $_option option"
@@ -1932,7 +1970,7 @@ xpns_parse_options() {
         XP_OPT_IS_SYNC=0
         ;;
       --log-format)
-        xpns_opt_check_str "$opt" "$1"
+        xpns_opt_checker "$opt" "$1" "string"
         XP_OPTIONS+=("$opt")
         XP_OPT_LOG_STORE=1
         TMUX_XPANES_LOG_FORMAT="$1"
@@ -1943,7 +1981,7 @@ xpns_parse_options() {
         XP_OPT_LOG_STORE=1
         XP_OPTIONS+=("$opt")
         TMUX_XPANES_LOG_DIRECTORY="${opt#--log=}"
-        xpns_opt_check_str "${opt%=}" "$TMUX_XPANES_LOG_DIRECTORY"
+        xpns_opt_checker "${opt%=}" "$TMUX_XPANES_LOG_DIRECTORY" "string"
         ;;
       --log)
         XP_OPT_LOG_STORE=1
@@ -1964,28 +2002,28 @@ xpns_parse_options() {
         XP_OPT_ATTACH=0
         ;;
       --cols)
-        xpns_opt_check_num "$opt" "$1"
+        xpns_opt_checker "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_OPT_CUSTOM_SIZE_COLS="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       --rows)
-        xpns_opt_check_num "$opt" "$1"
+        xpns_opt_checker "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_OPT_CUSTOM_SIZE_ROWS="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       --bulk-cols)
-        xpns_opt_check_num_csv "$opt" "$1"
+        xpns_opt_checker "$opt" "$1" "csv"
         XP_OPTIONS+=("$opt")
         XP_OPT_BULK_COLS="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       --interval)
-        xpns_opt_check_float "$opt" "$1"
+        xpns_opt_checker "$opt" "$1" "float"
         XP_OPTIONS+=("$opt")
         XP_OPT_INTERVAL="$1"
         XP_OPTIONS+=("$1")
@@ -2055,14 +2093,14 @@ xpns_parse_options() {
       # Short options with argument
       ## ----------------
       -I)
-        xpns_opt_check_str "$opt" "$1"
+        xpns_opt_checker "$opt" "$1" "string"
         XP_OPTIONS+=("$opt")
         XP_REPSTR="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       -l)
-        xpns_opt_check_str "$opt" "$1"
+        xpns_opt_checker "$opt" "$1" "string"
         XP_OPTIONS+=("$opt")
         XP_OPT_USE_PRESET_LAYOUT=1
         XP_LAYOUT="$(printf '%s\n' "$1" | xpns_layout_short2long)"
@@ -2072,7 +2110,6 @@ xpns_parse_options() {
         ;;
       -c)
         # -c allows empty
-        # xpns_opt_check_str "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_CMD_UTILITY="$1"
         XP_OPT_CMD_UTILITY=1
@@ -2080,28 +2117,28 @@ xpns_parse_options() {
         shift
         ;;
       -n)
-        xpns_opt_check_num "$opt" "$1"
+        xpns_opt_checker "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_MAX_PANE_ARGS="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       -S)
-        xpns_opt_check_str "$opt" "$1"
+        xpns_opt_checker "$opt" "$1" "string"
         XP_OPTIONS+=("$opt")
         XP_SOCKET_PATH="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       -C)
-        xpns_opt_check_num "$opt" "$1"
+        xpns_opt_checker "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_OPT_CUSTOM_SIZE_COLS="$1"
         XP_OPTIONS+=("$1")
         shift
         ;;
       -R)
-        xpns_opt_check_num "$opt" "$1"
+        xpns_opt_checker "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_OPT_CUSTOM_SIZE_ROWS="$1"
         XP_OPTIONS+=("$1")
@@ -2109,7 +2146,6 @@ xpns_parse_options() {
         ;;
       -B)
         # -B allows empty
-        # xpns_opt_check_str "$opt" "$1"
         XP_OPTIONS+=("$opt")
         XP_BEGIN_ARGS+=("$1")
         XP_OPTIONS+=("$1")

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -1845,7 +1845,7 @@ xpns_opt_checker() {
   local _arg="$2"
   local _check_value="${3:-default}"
   # if we do not define a positional parameter in options, we expect an integer
-  local _pattern="[0-9]"
+  local _pattern="^[0-9]+$"
   if [[ "$_check_value" == "float" ]]; then
     _pattern="^[0-9]*\.?[0-9]*$"
   elif [[ "$_check_value" == "csv" ]]; then

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -1847,7 +1847,7 @@ xpns_opt_checker() {
   # if we do not define a positional parameter in options, we expect an integer
   local _pattern="[0-9]"
   if [[ "$_check_value" == "float" ]]; then
-    _pattern="[0-9.]"
+    _pattern="^[0-9]*\.?[0-9]*$"
   elif [[ "$_check_value" == "csv" ]]; then
     _pattern="^[0-9]+(,[0-9]+)*$"
   elif [[ "$_check_value" == "string" ]]; then

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -512,5 +512,22 @@ test_xpns_parse_options_interval () {
   assertEquals "4" "$?"
 }
 
+test_xpns_opt_checker () {
+  ( xpns_opt_checker --bulk-cols 1,2,3,4 csv )
+  assertEquals "0" "$?"
+  ( xpns_opt_checker -n 1 )
+  assertEquals "0" "$?"
+  ( xpns_opt_checker -S ~/dummy string )
+  assertEquals "0" "$?"
+  ( xpns_opt_checker --interval 1.1 float )
+  assertEquals "0" "$?"
+  ( xpns_opt_checker --bulk-cols "invalid" csv )
+  assertEquals "4" "$?"
+  ( xpns_opt_checker -n "invalid" )
+  assertEquals "4" "$?"
+  ( xpns_opt_checker --interval "invalid" float )
+  assertEquals "4" "$?"
+}
+
 # shellcheck source=/dev/null
 . "${THIS_DIR}/shunit2/shunit2"

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -523,9 +523,15 @@ test_xpns_opt_checker () {
   assertEquals "0" "$?"
   ( xpns_opt_checker --bulk-cols "invalid" csv )
   assertEquals "4" "$?"
+  ( xpns_opt_checker --bulk-cols "1,2,a" csv )
+  assertEquals "4" "$?"
   ( xpns_opt_checker -n "invalid" )
   assertEquals "4" "$?"
+  ( xpns_opt_checker -n "1.1.1.1" )
+  assertEquals "4" "$?"
   ( xpns_opt_checker --interval "invalid" float )
+  assertEquals "4" "$?"
+  ( xpns_opt_checker --interval "1.1.1.1" float )
   assertEquals "4" "$?"
 }
 


### PR DESCRIPTION
With this change we remove four of the sanitation functions, to instead have a single main function for this purpose.
We are by default expecting an integer, if not an integer we are utilizing an additional positional parameters such as "csv" "string" or "float", which then changes the _pattern variable (except for string where we check if its populated).

With this change we can now scale much better and has the ability to add additional option sanitation checks easily with just another elif case.