### PR TITLE
optimize xpns_interval()

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -330,7 +330,7 @@ xpns_restore_allow_rename()  {
 
 xpns_interval() {
   local _interval="$1"
-  if [[ -n "${_interval-}" ]] && [[ "${_interval}" != "0" ]]; then
+  if (( _interval > 0 )); then
     sleep "${_interval}"
   fi
 }

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -330,7 +330,7 @@ xpns_restore_allow_rename()  {
 
 xpns_interval() {
   local _interval="$1"
-  if (( _interval > 0 )); then
+  if [[ "${_interval}" != "0" ]]; then
     sleep "${_interval}"
   fi
 }


### PR DESCRIPTION
Small change,

As we already sanitize the output via xpns_opt_checker() we do not need to sanitize it again, we only need to check if it does not equal 0 and sleep for said duration.