### PR TITLE
Change from "grep -c ." to "wc -l" for listings of panes.

### DIFF
--- a/bin/xpanes
+++ b/bin/xpanes
@@ -1581,7 +1581,7 @@ xpns_execution() {
 
   if [[ ${XP_OPT_REUSE} -eq 1 ]]; then
     _window_name="$( ${TMUX_XPANES_EXEC} display -p -F "#{window_id}")"
-    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l)"
+    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l | tr -dc '0-9')"
     _pane_base_index=$(($(${TMUX_XPANES_EXEC} display -p -F "#{pane_index}") + 1))
     _pane_active_pane_id=$(${TMUX_XPANES_EXEC} display -p -F "#{pane_id}")
 
@@ -1598,7 +1598,7 @@ xpns_execution() {
     # Reuse existing window name
     # tmux 1.6 does not support -F option
     _window_name="$( ${TMUX_XPANES_EXEC} display -p -F "#{window_id}")"
-    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l)"
+    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l | tr -dc '0-9')"
     _pane_base_index=$((_pane_base_index + _pane_count - 1))
     _pane_active_pane_id=$(${TMUX_XPANES_EXEC} display -p -F "#{pane_id}")
   elif [[ ${XP_OPT_REUSE} -eq 0 ]]; then
@@ -2046,7 +2046,7 @@ xpns_parse_options() {
         # Reusing the panes: if there's only 1 pane, behave like -x
         # This allows to run -r to create the panes and then repeatedly to reuse
         # those panes.
-        _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l)"
+        _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l | tr -dc '0-9')"
         if [[ ${_pane_count} -eq 1 ]]; then
           XP_OPT_EXTRA=1
           XP_OPT_USE_PRESET_LAYOUT=1 ## Layout presets must be used with -x

--- a/bin/xpanes
+++ b/bin/xpanes
@@ -1581,7 +1581,7 @@ xpns_execution() {
 
   if [[ ${XP_OPT_REUSE} -eq 1 ]]; then
     _window_name="$( ${TMUX_XPANES_EXEC} display -p -F "#{window_id}")"
-    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | grep -c .)"
+    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l)"
     _pane_base_index=$(($(${TMUX_XPANES_EXEC} display -p -F "#{pane_index}") + 1))
     _pane_active_pane_id=$(${TMUX_XPANES_EXEC} display -p -F "#{pane_id}")
 
@@ -1598,7 +1598,7 @@ xpns_execution() {
     # Reuse existing window name
     # tmux 1.6 does not support -F option
     _window_name="$( ${TMUX_XPANES_EXEC} display -p -F "#{window_id}")"
-    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | grep -c .)"
+    _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l)"
     _pane_base_index=$((_pane_base_index + _pane_count - 1))
     _pane_active_pane_id=$(${TMUX_XPANES_EXEC} display -p -F "#{pane_id}")
   elif [[ ${XP_OPT_REUSE} -eq 0 ]]; then
@@ -2046,7 +2046,7 @@ xpns_parse_options() {
         # Reusing the panes: if there's only 1 pane, behave like -x
         # This allows to run -r to create the panes and then repeatedly to reuse
         # those panes.
-        _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | grep -c .)"
+        _pane_count="$( ${TMUX_XPANES_EXEC} list-panes | wc -l)"
         if [[ ${_pane_count} -eq 1 ]]; then
           XP_OPT_EXTRA=1
           XP_OPT_USE_PRESET_LAYOUT=1 ## Layout presets must be used with -x


### PR DESCRIPTION
for a small performance gain, during our listing panes.
We can utilize wc command instead.

**So what is the difference?**
wc -l is a simple byte scanner — it just counts \n characters. It's a basic utility with minimal overhead.
grep -c . has to load the regex engine, compile the pattern ., and evaluate each line against it. More work for the same result.

**So what is the catch?**
in certain circumstance they can give different results:
 echo -n "no trailing newline" > file.txt
 wc -l < file.txt    # 0  (counts newlines, not lines)
 grep -c . < file.txt  # 1  (matches the line even without \n)



Fortuneatly for the usecase we have in list-panes command, we always get newlines:
<img width="525" height="195" alt="image" src="https://github.com/user-attachments/assets/d9d10906-547d-4cc3-b83a-5380fcb71e0d" />

Tested with cases_smoke.sh, have issues with cases_all.sh on main branch as well, but if you can test it with cases_all.sh it would be great. 